### PR TITLE
fix onSubmit page refresh in production for SignIn button

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -3,6 +3,7 @@ import Button from "@elements/Button";
 import TextBox from "@elements/TextBox";
 import { signIn } from "next-auth/react";
 import { useRef } from "react";
+import React from "react"
 
 interface IProps {
   searchParams?: { [key: string]: string | string[] | undefined };
@@ -12,7 +13,8 @@ const LoginPage = ({ searchParams }: IProps) => {
   const userName = useRef("");
   const pass = useRef("");
 
-  const onSubmit = async () => {
+  const onSubmit = async (event: React.SyntheticEvent) => {
+    event.preventDefault();
     const result = await signIn("credentials", {
       username: userName.current,
       password: pass.current,


### PR DESCRIPTION
I used your authentication in production, but every time I clicked on the signIn button which is handled by NextAuth it would take do a quick refresh due to the lack of the eventDefault() and I would land up in a 404 page. After preventing the default behaviour I am now successfully able to go back to whatever callback URL I have mentioned in the code. 